### PR TITLE
Amended chat thread name update to include storing previous name

### DIFF
--- a/src/features/chat/chat-services/chat-thread-service.ts
+++ b/src/features/chat/chat-services/chat-thread-service.ts
@@ -106,6 +106,7 @@ export const UpdateChatThreadTitle = async (
     const response = await FindChatThreadForCurrentUser(chatThreadId)
     if (response.status !== "OK") return response
     const chatThread = response.response
+    chatThread.previousChatName = chatThread.name
     chatThread.name = newTitle.substring(0, 30)
     return await UpsertChatThread(chatThread)
   } catch (error) {
@@ -277,14 +278,9 @@ export const InitChatSession = async (
   const updatedChatThreadResponse = await UpsertChatThread({
     ...currentChatThreadResponse.response,
     chatType: chatType,
-    chatCategory: "Uncategorised",
     chatOverFileName: chatOverFileName,
     conversationStyle: conversationStyle,
     conversationSensitivity: conversationSensitivity,
-    name: "New Chat",
-    previousChatName: "",
-    prompts: [],
-    selectedPrompt: "",
   })
   if (updatedChatThreadResponse.status !== "OK") return updatedChatThreadResponse
 


### PR DESCRIPTION
Also removed the unnecessary recasting of chat name, category, prompts, selected prompts and previous chat name from the upsertthread function