### PR TITLE
Update feedbackHeading variant to use text-secondary color in modal.tsx

### DIFF
--- a/src/features/ui/modal.tsx
+++ b/src/features/ui/modal.tsx
@@ -29,7 +29,7 @@ export default function Modal(props: ModalProps): ReturnType<FC> {
     >
       <div className="mx-auto w-full max-w-lg overflow-hidden rounded-lg bg-background p-4">
         <div className="mb-4">
-          <Typography id="feedbackHeading" variant="h4" className="text-primary">
+          <Typography id="feedbackHeading" variant="h4" className="text-secondary">
             Submit your feedback
           </Typography>
         </div>


### PR DESCRIPTION
This pull request includes a minor change to the `Modal` function in the `src/features/ui/modal.tsx` file. The change modifies the `Typography` component's className from `text-primary` to `text-secondary`, which will likely alter the color of the text in the feedback heading.