### PR TITLE
Refactor chat services and import statements in chat-thread-service.ts

### DIFF
--- a/src/features/chat/chat-services/chat-thread-service.ts
+++ b/src/features/chat/chat-services/chat-thread-service.ts
@@ -2,6 +2,9 @@
 import "server-only"
 import { SqlQuerySpec } from "@azure/cosmos"
 
+import { FindAllChatDocumentsForCurrentUser } from "./chat-document-service"
+import { FindAllChatMessagesForCurrentUser } from "./chat-message-service"
+
 import { getCurrentUser, getTenantId, userHashedId, userSession } from "@/features/auth/helpers"
 import { deleteDocuments } from "@/features/chat/chat-services/azure-cog-search/azure-cog-vector-store"
 import { DEFAULT_MONTHS_AGO } from "@/features/chat/constants"
@@ -22,9 +25,6 @@ import { RedirectToChatThread } from "@/features/common/navigation-helpers"
 import { ServerActionResponseAsync } from "@/features/common/server-action-response"
 import { HistoryContainer } from "@/features/common/services/cosmos"
 import { uniqueId } from "@/lib/utils"
-
-import { FindAllChatDocumentsForCurrentUser } from "./chat-document-service"
-import { FindAllChatMessagesForCurrentUser } from "./chat-message-service"
 
 export const FindAllChatThreadForCurrentUser = async (): ServerActionResponseAsync<ChatThreadModel[]> => {
   try {
@@ -308,7 +308,7 @@ export const InitChatSession = async (props: PromptGPTProps): ServerActionRespon
       chatThreadId,
       updatedLastHumanMessage,
       chats: chatMessagesResponse.response,
-      chatThread: currentChatThreadResponse.response,
+      chatThread: updatedChatThreadResponse.response,
     },
   }
 }


### PR DESCRIPTION
This pull request primarily focuses on refactoring the `src/features/chat/chat-services/chat-thread-service.ts` file. The changes involve reorganization of import statements and an update to the `InitChatSession` function.

Here's a summary of the most important changes:

* [`src/features/chat/chat-services/chat-thread-service.ts`](diffhunk://#diff-bddad34450c7e7af3d06ffd22ebcde980e85c8af1017de49bfc10f96c7084758R5-R7): The import statements for `FindAllChatDocumentsForCurrentUser` and `FindAllChatMessagesForCurrentUser` were moved to the top of the file to improve code readability and maintainability. [[1]](diffhunk://#diff-bddad34450c7e7af3d06ffd22ebcde980e85c8af1017de49bfc10f96c7084758R5-R7) [[2]](diffhunk://#diff-bddad34450c7e7af3d06ffd22ebcde980e85c8af1017de49bfc10f96c7084758L26-L28)
* [`src/features/chat/chat-services/chat-thread-service.ts`](diffhunk://#diff-bddad34450c7e7af3d06ffd22ebcde980e85c8af1017de49bfc10f96c7084758L311-R311): In the `InitChatSession` function, `currentChatThreadResponse.response` was replaced with `updatedChatThreadResponse.response`. This change suggests that the chat thread response is now being updated during the initialization of a chat session.