### PR TITLE
Fix typo in page title for Unauthorised

### DIFF
--- a/src/app/unauthorised/layout.tsx
+++ b/src/app/unauthorised/layout.tsx
@@ -1,8 +1,8 @@
 import { AI_NAME } from "@/features/theme/theme-config"
 
 export const metadata = {
-  title: AI_NAME + " Unathorised",
-  description: AI_NAME + " - Unathorised",
+  title: AI_NAME + " Unauthorised",
+  description: AI_NAME + " - Unauthorised",
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }): JSX.Element {


### PR DESCRIPTION
This pull request includes a minor spelling correction in the `src/app/unauthorised/layout.tsx` file. The words "Unathorised" were corrected to "Unauthorised" in both the `title` and `description` fields of the `metadata` object.