### PR TITLE
Google Tag Manager Changes

### DIFF
--- a/src/next.config.js
+++ b/src/next.config.js
@@ -24,7 +24,7 @@ const securityHeaders = [
   {
     key: "Content-Security-Policy",
     value:
-      "default-src 'self'; script-src https://www.google-analytics.com/ 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com; style-src *.typekit.net 'self' 'unsafe-inline'; frame-ancestors 'self'; img-src 'self' https://www.google.com https://www.google.com.au data:; font-src *.typekit.net 'self' data:; connect-src 'self'  https://js.monitor.azure.com https://qdap-dev-apim.azure-api.net https://qdap-prd-apim.developer.azure-api.net *.ai.qld.gov.au *.applicationinsights.azure.com https://australiaeast.livediagnostics.monitor.azure.com https://analytics.google.com https://www.google-analytics.com https://www.google-analytics.com https://stats.g.doubleclick.net; media-src 'self'; frame-src 'self'; object-src 'none'; upgrade-insecure-requests",
+      "default-src 'self'; script-src https://www.google-analytics.com/ 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com; style-src *.typekit.net 'self' 'unsafe-inline'; frame-ancestors 'self'; img-src 'self' https://www.google.com https://www.google.com.au data:; font-src *.typekit.net 'self' data:; connect-src 'self'  https://www.google.com.au/ads https://js.monitor.azure.com https://qdap-dev-apim.azure-api.net https://qdap-prd-apim.developer.azure-api.net *.ai.qld.gov.au *.applicationinsights.azure.com https://australiaeast.livediagnostics.monitor.azure.com https://analytics.google.com https://www.google-analytics.com https://www.google-analytics.com https://stats.g.doubleclick.net; media-src 'self'; frame-src 'self'; object-src 'none'; upgrade-insecure-requests",
   },
   {
     key: "Referrer-Policy",

--- a/src/next.config.js
+++ b/src/next.config.js
@@ -24,7 +24,7 @@ const securityHeaders = [
   {
     key: "Content-Security-Policy",
     value:
-      "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com; style-src *.typekit.net 'self' 'unsafe-inline'; frame-ancestors 'self'; img-src 'self' https://www.google.com https://www.google.com.au data:; font-src *.typekit.net 'self' data:; connect-src 'self'  https://js.monitor.azure.com https://qdap-dev-apim.azure-api.net https://qdap-prd-apim.developer.azure-api.net *.ai.qld.gov.au *.applicationinsights.azure.com https://australiaeast.livediagnostics.monitor.azure.com https://analytics.google.com https://www.google-analytics.com https://www.google-analytics.com https://stats.g.doubleclick.net; media-src 'self'; frame-src 'self'; object-src 'none'; upgrade-insecure-requests",
+      "default-src 'self'; script-src https://www.google-analytics.com/ 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com; style-src *.typekit.net 'self' 'unsafe-inline'; frame-ancestors 'self'; img-src 'self' https://www.google.com https://www.google.com.au data:; font-src *.typekit.net 'self' data:; connect-src 'self'  https://js.monitor.azure.com https://qdap-dev-apim.azure-api.net https://qdap-prd-apim.developer.azure-api.net *.ai.qld.gov.au *.applicationinsights.azure.com https://australiaeast.livediagnostics.monitor.azure.com https://analytics.google.com https://www.google-analytics.com https://www.google-analytics.com https://stats.g.doubleclick.net; media-src 'self'; frame-src 'self'; object-src 'none'; upgrade-insecure-requests",
   },
   {
     key: "Referrer-Policy",


### PR DESCRIPTION
This pull request involves a change in the Content Security Policy (CSP) in the `src/next.config.js` file. The CSP is an important security feature that helps prevent a wide range of security threats, including cross-site scripting (XSS), clickjacking, and other code injection attacks. The change in this pull request modifies the `script-src` and `connect-src` directives of the CSP.

* [`src/next.config.js`](diffhunk://#diff-c7ecd7b684200d677fdfca50895b9549ac853ccb5f3665f3fe0cf27081f6b892L27-R27): The `script-src` directive, which controls which scripts the protected resource can execute, was updated to include `https://www.google-analytics.com/` as a trusted source. The `connect-src` directive, which controls which URLs the protected resource can load using script interfaces, was updated to include `https://www.google.com.au/ads` as a trusted source. This change allows scripts from Google Analytics and connections to Google Ads, which can be useful for tracking user behavior and displaying ads, respectively.