### PR TITLE
disabled auto scroll if user scrolled up while loading

### DIFF
--- a/src/components/hooks/use-chat-scroll-anchor.tsx
+++ b/src/components/hooks/use-chat-scroll-anchor.tsx
@@ -3,10 +3,10 @@
 import { Message } from "ai"
 import { RefObject, useEffect } from "react"
 
-export const useChatScrollAnchor = (chats: Message[], ref: RefObject<HTMLDivElement>): void => {
+export const useChatScrollAnchor = (chats: Message[], ref: RefObject<HTMLDivElement>, enabled: boolean): void => {
   useEffect(() => {
-    if (ref && ref.current) {
+    if (ref && ref.current && enabled) {
       ref.current.scrollTop = ref.current.scrollHeight
     }
-  }, [chats, ref])
+  }, [chats, ref, enabled])
 }

--- a/src/features/chat/chat-ui/chat-message-container.tsx
+++ b/src/features/chat/chat-ui/chat-message-container.tsx
@@ -24,7 +24,10 @@ export const ChatMessageContainer: React.FC<Props> = ({ chatThreadId }) => {
   const { messages, documents, isLoading, chatThreadLocked } = useChatContext()
   const [selectedTab, setSelectedTab] = useState<SectionTabsProps["selectedTab"]>("chat")
 
-  useChatScrollAnchor(messages, scrollRef)
+  const [previousScrollTop, setPreviousScrollTop] = useState(0)
+  const [supressScrolling, setSupressScrolling] = useState(false)
+
+  useChatScrollAnchor(messages, scrollRef, !supressScrolling)
 
   useEffect(() => {
     if (!isLoading) {
@@ -32,10 +35,25 @@ export const ChatMessageContainer: React.FC<Props> = ({ chatThreadId }) => {
     }
   }, [isLoading, router])
 
+  useEffect(() => {
+    if (isLoading) {
+      setSupressScrolling(false)
+    }
+  }, [isLoading])
+
+  const onScroll = (e: React.UIEvent<HTMLDivElement>): void => {
+    if (isLoading) {
+      if (e.currentTarget.scrollTop < previousScrollTop) {
+        setSupressScrolling(true)
+      }
+      setPreviousScrollTop(e.currentTarget.scrollTop)
+    }
+  }
+
   const documentsWithTranscriptions = documents.filter(document => document.contents)
 
   return (
-    <div className="h-full overflow-y-auto" ref={scrollRef}>
+    <div className="h-full overflow-y-auto" ref={scrollRef} onScroll={onScroll}>
       <div className="flex h-auto justify-center p-2">
         <ChatHeader />
       </div>


### PR DESCRIPTION
This pull request contains changes to the `src/components/hooks/use-chat-scroll-anchor.tsx` and `src/features/chat/chat-ui/chat-message-container.tsx` files. The changes primarily focus on modifying the `useChatScrollAnchor` hook and the `ChatMessageContainer` component to control the scrolling behavior based on the loading state.

Fixes https://github.com/QDAP-DATAAI/qchat/issues/88

Here are the most important changes:

* [`src/components/hooks/use-chat-scroll-anchor.tsx`](diffhunk://#diff-93d2674ef068f36aec5e73a788c03d1bb5275c18f3fe34f7d27e1b17d2a5b2b0L6-R11): The `useChatScrollAnchor` hook was modified to accept a new `enabled` parameter. This parameter is used to control whether the chat should auto-scroll to the bottom. If `enabled` is `true`, the chat will auto-scroll to the bottom. If `enabled` is `false`, the auto-scrolling feature will be disabled.

* [`src/features/chat/chat-ui/chat-message-container.tsx`](diffhunk://#diff-66d171166e4023058f819822019dea9362992c85c7c5e769a1c207017002db41L27-R56): Several changes were made to the `ChatMessageContainer` component. First, two new state variables, `previousScrollTop` and `supressScrolling`, were introduced. The `previousScrollTop` variable keeps track of the previous scroll position, while the `supressScrolling` variable is used to control whether the auto-scrolling feature should be suppressed. The `useChatScrollAnchor` hook was also modified to use the `supressScrolling` state variable. Furthermore, a new `onScroll` event handler was added to the chat container. This handler suppresses the auto-scrolling feature if the user is scrolling up while the chat is loading. Finally, the `isLoading` state variable was used to reset the `supressScrolling` state variable once the loading is finished.