### PR TITLE
fix: Remove unnecessary id assignment in CreateUser function

### DIFF
--- a/src/features/user-management/user-service.ts
+++ b/src/features/user-management/user-service.ts
@@ -14,7 +14,6 @@ export const CreateUser = async (user: UserRecord): ServerActionResponseAsync<Us
     const historyLog = `${creationDate}: User created by ${user.upn}`
     const { resource } = await container.items.create<UserRecord>({
       ...user,
-      id: user.upn,
       history: [historyLog],
     })
     if (!resource)


### PR DESCRIPTION
The most important change is the removal of the `id` assignment when creating a new user record.
Creates item with hashed id

Changes:

* [`src/features/user-management/user-service.ts`](diffhunk://#diff-f920b8023676a47af86171079ecb6c563ef26918258b3ffe428ed0b4d518e2e3L17): Removed the line of code that assigns the `id` of the new user record to `user.upn` in the `CreateUser` function. This change suggests that the `id` of a new user record will no longer be explicitly set to the `upn` of the user.