### PR TITLE
save context to chat message

### DIFF
--- a/src/features/chat/chat-services/chat-api-helper.ts
+++ b/src/features/chat/chat-services/chat-api-helper.ts
@@ -81,6 +81,7 @@ export const buildDataChatMessages = async (
 ): Promise<{
   systemMessage: ChatCompletionMessageParam
   userMessage: ChatCompletionMessageParam
+  context: string
 }> => {
   const relevantDocuments = await findRelevantDocuments(lastChatMessage.content, chatThreadId)
   const context = relevantDocuments
@@ -100,5 +101,6 @@ export const buildDataChatMessages = async (
       role: ChatRole.User,
       content: buildDataChatContextPrompt(context, lastChatMessage.content),
     },
+    context,
   }
 }

--- a/src/features/chat/chat-services/chat-api.ts
+++ b/src/features/chat/chat-services/chat-api.ts
@@ -38,6 +38,7 @@ export const ChatApi = async (props: PromptProps): Promise<Response> => {
 
     let userMessage: ChatCompletionMessageParam
     let metaPrompt: ChatCompletionMessageParam
+    let context: string = ""
     let translate: (input: string) => Promise<string>
 
     if (props.chatType === "simple" || !dataChatTypes.includes(props.chatType)) {
@@ -53,7 +54,7 @@ export const ChatApi = async (props: PromptProps): Promise<Response> => {
       const res = await buildDataChatMessages(updatedLastHumanMessage, chatThread.chatThreadId)
       userMessage = res.userMessage
       metaPrompt = res.systemMessage
-
+      context = res.context
       translate = async (_input: string): Promise<string> => await Promise.resolve("")
     }
 
@@ -86,7 +87,7 @@ export const ChatApi = async (props: PromptProps): Promise<Response> => {
       chatThreadId: chatThread.id,
       userId: chatThread.userId,
       tenantId: chatThread.tenantId,
-      context: "",
+      context: context,
       systemPrompt: contextPrompts.metaPrompt,
       tenantPrompt: contextPrompts.tenantPrompt,
       userPrompt: contextPrompts.userPrompt,


### PR DESCRIPTION
This pull request primarily focuses on the addition of a `context` variable in the `ChatApi` and `buildDataChatMessages` functions in the `chat-api.ts` and `chat-api-helper.ts` files respectively. The `context` variable is used to store relevant documents related to the last chat message and is passed through various functions to be used in the `ChatApi` function.

Addition of `context` variable:

* [`src/features/chat/chat-services/chat-api-helper.ts`](diffhunk://#diff-6d77056e441a1e3e83af3fb3c1d13c45e30a871dc6fe39be966b224dd004d3ffR84): The `buildDataChatMessages` function now returns a `context` variable that is assigned the value of `relevantDocuments`, which contains documents relevant to the last chat message. [[1]](diffhunk://#diff-6d77056e441a1e3e83af3fb3c1d13c45e30a871dc6fe39be966b224dd004d3ffR84) [[2]](diffhunk://#diff-6d77056e441a1e3e83af3fb3c1d13c45e30a871dc6fe39be966b224dd004d3ffR104)
* [`src/features/chat/chat-services/chat-api.ts`](diffhunk://#diff-165fc4d4be73e722a9fcc419023d14d90a99a578802a1516032500b86d3f6ac1R41): The `ChatApi` function now initializes a `context` variable and assigns it the `context` returned from the `buildDataChatMessages` function. This `context` is then used as a parameter in the `ChatApi` function. [[1]](diffhunk://#diff-165fc4d4be73e722a9fcc419023d14d90a99a578802a1516032500b86d3f6ac1R41) [[2]](diffhunk://#diff-165fc4d4be73e722a9fcc419023d14d90a99a578802a1516032500b86d3f6ac1L56-R57) [[3]](diffhunk://#diff-165fc4d4be73e722a9fcc419023d14d90a99a578802a1516032500b86d3f6ac1L89-R90)