### PR TITLE
feat: Add show more/less functionality to administrators list

### DIFF
--- a/src/features/settings/tenant-details/administrators.tsx
+++ b/src/features/settings/tenant-details/administrators.tsx
@@ -19,15 +19,17 @@ export const Administrators: React.FC<{ administrators: string[] }> = ({ adminis
             <b>{admin}</b>
           </div>
         ))}
-      <div
-        className={
-          "mt-2 flex w-full transform cursor-pointer justify-center gap-2 rounded-md border-2 border-altBorder duration-300 animate-in"
-        }
-        onClick={() => setShowMore(!showMore)}
-      >
-        {showMore ? "Show Less" : "Show More"}
-        <ChevronUpIcon className={`h-6 w-6 transform duration-300 animate-in ${showMore ? "" : "rotate-180"}`} />
-      </div>
+      {administrators.length > DEFAULT_ITEMS_TO_SHOW && (
+        <div
+          className={
+            "mt-2 flex w-full transform cursor-pointer justify-center gap-2 rounded-md border-2 border-altBorder duration-300 animate-in"
+          }
+          onClick={() => setShowMore(!showMore)}
+        >
+          {showMore ? "Show Less" : "Show More"}
+          <ChevronUpIcon className={`h-6 w-6 transform duration-300 animate-in ${showMore ? "" : "rotate-180"}`} />
+        </div>
+      )}
     </Typography>
   )
 }


### PR DESCRIPTION
This pull request includes changes to the `Administrators` component in the `src/features/settings/tenant-details/administrators.tsx` file. The changes add a conditional rendering block that shows more or less information based on the length of the `administrators` array.

Key changes:

* [`src/features/settings/tenant-details/administrators.tsx`](diffhunk://#diff-6ac15ff5bce73aa784fddeb562d71df105df07f61f5d562fc62eeb9036d6733eR22): Added a conditional rendering block that checks if the length of the `administrators` array is greater than `DEFAULT_ITEMS_TO_SHOW`. If true, it renders a "Show More" or "Show Less" button along with a `ChevronUpIcon`. [[1]](diffhunk://#diff-6ac15ff5bce73aa784fddeb562d71df105df07f61f5d562fc62eeb9036d6733eR22) [[2]](diffhunk://#diff-6ac15ff5bce73aa784fddeb562d71df105df07f61f5d562fc62eeb9036d6733eR32)