### PR TITLE
fix: Announcement dialogs behaviour & Citation component

### DIFF
--- a/src/app/api/application/[content]/route.ts
+++ b/src/app/api/application/[content]/route.ts
@@ -1,0 +1,15 @@
+import fs from "fs/promises"
+
+import { NextRequest } from "next/server"
+
+const loadContent = async (content: string): Promise<string> => {
+  return await fs.readFile(process.cwd() + `/public/${content}.md`, "utf8")
+}
+
+export async function GET(_request: NextRequest, { params }: { params: { content: string } }): Promise<Response> {
+  const content = await loadContent(params.content)
+  return new Response(content, {
+    status: 200,
+    headers: { "Content-Type": "text/markdown" },
+  })
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,7 @@
 import { redirect } from "next/navigation"
 
-import { LogIn } from "@/components/login/login"
-import { userSession } from "@/features/auth/helpers"
-
 export const dynamic = "force-dynamic"
 
-export default async function Home(): Promise<JSX.Element> {
-  const user = await userSession()
-  if (user) {
-    redirect("/chat")
-  }
-  return (
-    <div className="col-span-12 size-full">
-      <LogIn />
-    </div>
-  )
+export default function Home(): void {
+  redirect("/chat")
 }

--- a/src/components/announcement/agree-terms-and-conditions.tsx
+++ b/src/components/announcement/agree-terms-and-conditions.tsx
@@ -48,12 +48,15 @@ export default function AgreeTermsAndConditions({ onClose }: AgreeTermsAndCondit
   }
 
   useEffect(() => {
-    fetch(`${window.location.origin}/terms.md`)
+    fetch("/api/application/terms")
       .then(async response => await response.text())
       .then(data => setContent(data))
-      .catch(() => setContent("Failed to load terms and conditions, please try again later."))
+      .catch(() => {
+        logger.error("Failed to load terms and conditions, please try again later.")
+        onClose()
+      })
       .finally(() => setIsLoading(false))
-  }, [])
+  }, [onClose])
 
   useEffect(() => {
     if (isEndOfScroll) setCanSubmit(true)

--- a/src/components/announcement/whats-new-modal.tsx
+++ b/src/components/announcement/whats-new-modal.tsx
@@ -42,16 +42,24 @@ export default function WhatsNewModal({ targetVersion, onClose }: WhatsNewModalP
     }
   }, [onClose, targetVersion, update])
 
+  const handleClickOutside = (): void => {
+    sessionStorage.setItem("whats-new-dismissed", new Date().toISOString())
+    onClose()
+  }
+
   useEffect(() => {
-    fetch(`${window.location.origin}/whats-new.md`)
+    fetch("/api/application/whats-new")
       .then(async response => await response.text())
       .then(data => setContent(data))
-      .catch(() => setContent("Failed to load terms and conditions, please try again later."))
+      .catch(() => {
+        logger.error("Failed to load the latest news, please try again later.")
+        onClose()
+      })
       .finally(() => setIsLoading(false))
-  }, [])
+  }, [onClose])
 
   return (
-    <Dialog onClose={onClose}>
+    <Dialog onClose={handleClickOutside}>
       <DialogHeader>What&apos;s new</DialogHeader>
       <DialogContent>
         <div className="prose prose-slate max-w-4xl break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0">

--- a/src/components/markdown/config.tsx
+++ b/src/components/markdown/config.tsx
@@ -1,9 +1,17 @@
 import { Config } from "@markdoc/markdoc"
 
-import { citation } from "@/features/chat/chat-ui/markdown/citation"
-
 import { fence } from "./code-block"
 import { paragraph } from "./paragraph"
+
+const citation = {
+  render: "Citation",
+  selfClosing: true,
+  attributes: {
+    items: {
+      type: Array,
+    },
+  },
+}
 
 export const citationConfig: Config = {
   nodes: {

--- a/src/features/chat/chat-ui/markdown/citation-slider.tsx
+++ b/src/features/chat/chat-ui/markdown/citation-slider.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { FC } from "react"
 import { useFormState } from "react-dom"
 

--- a/src/features/chat/chat-ui/markdown/citation.tsx
+++ b/src/features/chat/chat-ui/markdown/citation.tsx
@@ -1,4 +1,3 @@
-"use client"
 import { FC } from "react"
 
 import Typography from "@/components/typography"
@@ -16,16 +15,6 @@ interface Citation {
 
 interface Props {
   items: Citation[]
-}
-
-export const citation = {
-  render: "Citation",
-  selfClosing: true,
-  attributes: {
-    items: {
-      type: Array,
-    },
-  },
 }
 
 export const Citation: FC<Props> = (props: Props) => {

--- a/src/features/globals/global-message-context.tsx
+++ b/src/features/globals/global-message-context.tsx
@@ -34,8 +34,8 @@ export const GlobalMessageProvider = ({ children }: { children: React.ReactNode 
     // check for terms and conditions
     const tAndCs = application.appSettings.termsAndConditionsDate
     if (
-      (application.appSettings.termsAndConditionsDate && !session.user.acceptedTermsDate) || // first time user
-      new Date(tAndCs).getTime() > new Date(session.user.acceptedTermsDate).getTime() // new terms
+      (application.appSettings.termsAndConditionsDate && !session.user.acceptedTermsDate) ||
+      new Date(tAndCs).getTime() > new Date(session.user.acceptedTermsDate).getTime()
     ) {
       announcement.newsflash(<AgreeTermsAndConditions onClose={() => !unsubscribe && announcement.dismiss()} />)
       return
@@ -43,8 +43,9 @@ export const GlobalMessageProvider = ({ children }: { children: React.ReactNode 
 
     // check for new what's new
     if (
-      !pathname.endsWith("/whats-new") && // don't show on the what's new page
-      application.appSettings.version !== session.user.lastVersionSeen // new version
+      !sessionStorage.getItem("whats-new-dismissed") &&
+      !pathname.endsWith("/whats-new") &&
+      application.appSettings.version !== session.user.lastVersionSeen
     ) {
       announcement.newsflash(
         <WhatsNewModal

--- a/src/features/globals/global-message-context.tsx
+++ b/src/features/globals/global-message-context.tsx
@@ -16,6 +16,7 @@ interface GlobalMessageProps {
 }
 
 const GlobalMessageContext = createContext<GlobalMessageProps | null>(null)
+const DELAY_ANNOUNCEMENTS = 3000
 
 interface MessageProp {
   title: string
@@ -31,33 +32,36 @@ export const GlobalMessageProvider = ({ children }: { children: React.ReactNode 
     if (!session?.user || !application?.appSettings) return
     let unsubscribe = false
 
-    // check for terms and conditions
-    const tAndCs = application.appSettings.termsAndConditionsDate
-    if (
-      (application.appSettings.termsAndConditionsDate && !session.user.acceptedTermsDate) ||
-      new Date(tAndCs).getTime() > new Date(session.user.acceptedTermsDate).getTime()
-    ) {
-      announcement.newsflash(<AgreeTermsAndConditions onClose={() => !unsubscribe && announcement.dismiss()} />)
-      return
-    }
+    const timeoutId = setTimeout(() => {
+      // check for terms and conditions
+      const tAndCs = application.appSettings.termsAndConditionsDate
+      if (
+        (application.appSettings.termsAndConditionsDate && !session.user.acceptedTermsDate) ||
+        new Date(tAndCs).getTime() > new Date(session.user.acceptedTermsDate).getTime()
+      ) {
+        announcement.newsflash(<AgreeTermsAndConditions onClose={() => !unsubscribe && announcement.dismiss()} />)
+        return
+      }
 
-    // check for new what's new
-    if (
-      !sessionStorage.getItem("whats-new-dismissed") &&
-      !pathname.endsWith("/whats-new") &&
-      application.appSettings.version !== session.user.lastVersionSeen
-    ) {
-      announcement.newsflash(
-        <WhatsNewModal
-          targetVersion={application.appSettings.version}
-          onClose={() => !unsubscribe && announcement.dismiss()}
-        />
-      )
-      return
-    }
+      // check for new what's new
+      if (
+        !sessionStorage.getItem("whats-new-dismissed") &&
+        !pathname.endsWith("/whats-new") &&
+        application.appSettings.version !== session.user.lastVersionSeen
+      ) {
+        announcement.newsflash(
+          <WhatsNewModal
+            targetVersion={application.appSettings.version}
+            onClose={() => !unsubscribe && announcement.dismiss()}
+          />
+        )
+        return
+      }
+    }, DELAY_ANNOUNCEMENTS)
 
     return () => {
       unsubscribe = true
+      clearTimeout(timeoutId)
     }
   }, [session?.user, application?.appSettings, pathname])
 

--- a/src/features/globals/providers.tsx
+++ b/src/features/globals/providers.tsx
@@ -12,8 +12,8 @@ import { GlobalMessageProvider } from "./global-message-context"
 export const Providers = ({ children }: { children: React.ReactNode }): JSX.Element => {
   return (
     <SessionProvider refetchInterval={15 * 60} basePath="/api/auth">
-      <Announcements />
       <GlobalMessageProvider>
+        <Announcements />
         <MenuProvider>
           <MiniMenuProvider>
             <TooltipProvider>{children}</TooltipProvider>

--- a/src/features/ui/user-login-logout.tsx
+++ b/src/features/ui/user-login-logout.tsx
@@ -2,7 +2,6 @@
 
 import { LogIn, LogOut } from "lucide-react"
 import { useSession, signIn, signOut } from "next-auth/react"
-import React, { useEffect, useState } from "react"
 
 import { signInProvider } from "@/app-global"
 
@@ -11,23 +10,9 @@ import { Button } from "@/features/ui/button"
 
 export const UserComponent: React.FC = () => {
   const { data: session, status } = useSession({ required: false })
-  const [isLoading, setIsLoading] = useState(status === "loading")
 
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout
-    if (status === "loading") {
-      timeoutId = setTimeout(() => {
-        setIsLoading(false)
-      }, 10000) // 10 seconds timeout
-    } else {
-      setIsLoading(false)
-    }
-    return () => clearTimeout(timeoutId)
-  }, [status])
-
-  if (isLoading) {
+  if (status === "loading")
     return <div className="flex h-[32px] w-full items-center justify-center opacity-50">Loading...</div>
-  }
 
   return (
     <div>

--- a/src/package.json
+++ b/src/package.json
@@ -14,7 +14,6 @@
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input --cache --cache-strategy=content --cache-location=.stylelintcache",
     "prettier": "prettier \"**/*.{js,mjs,ts,tsx,md,mdx,json,yml,css}\" --check --cache --cache-strategy=content --cache-location=.prettiercache",
     "lint:fix": "npm run lint:js -- --fix && npm run lint:css -- --fix && npm run prettier -- --write",
-    "model": "npx ts-node --project tsconfig.script.json generate-model-report.ts",
     "test": "playwright test",
     "jest": "jest",
     "prepare": "cd .. && husky src/.husky"


### PR DESCRIPTION
This pull request primarily involves refactoring and reorganization of the citation handling in the markdown feature of the chat UI. The `citation` object has been moved from `src/features/chat/chat-ui/markdown/citation.tsx` to `src/components/markdown/config.tsx`. Additionally, the `use client` directive has been shifted between these two files. The `Announcements` component in `src/features/globals/providers.tsx` has also been moved within the `Providers` component.

Refactoring and reorganization:

* [`src/components/markdown/config.tsx`](diffhunk://#diff-cfd70dc08e0f33c6327be848091775738683b5d962cbd65f7a8c951b6b8ba82eL3-R15): The `citation` object was added to this file. It was previously in `src/features/chat/chat-ui/markdown/citation.tsx`.
* [`src/features/chat/chat-ui/markdown/citation-slider.tsx`](diffhunk://#diff-7614620f7785b67db7de28d5ccea50169361baf3d4e50e582dd255040aca50f7R1-R2): The `use client` directive was added to this file. It was previously in `src/features/chat/chat-ui/markdown/citation.tsx`.
* [`src/features/globals/providers.tsx`](diffhunk://#diff-2ad9105c51ece7403c61f68882ec9bda45fe2df4d9794bb9ce606740a84fa290L15-R16): The `Announcements` component was moved within the `Providers` component.