### PR TITLE
chore: Select component to match other inputs styling & fix default value

### DIFF
--- a/src/app/settings/admin/selectors.tsx
+++ b/src/app/settings/admin/selectors.tsx
@@ -37,10 +37,10 @@ export const Selectors = (): JSX.Element => {
 
   return (
     <div className="m-4 flex items-center gap-4">
-      <div className="flex w-full flex-1 items-center">
+      <div className="flex flex-1 items-center">
         <Select
-          value={selectedTenant?.id || "placeholder"}
-          groups={[
+          value={selectedTenant?.id || ""}
+          options={[
             {
               label: "Tenants",
               options: tenants.map(t => ({
@@ -53,10 +53,10 @@ export const Selectors = (): JSX.Element => {
           onValueChange={handleSelectTenant}
         />
       </div>
-      <div className="flex w-full flex-1 items-center">
+      <div className="flex flex-1 items-center">
         <Select
-          value={selectedUser?.id || "placeholder"}
-          groups={[
+          value={selectedUser?.id || ""}
+          options={[
             {
               label: "Users",
               options: users.map(u => ({

--- a/src/features/ui/input.tsx
+++ b/src/features/ui/input.tsx
@@ -16,7 +16,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         accept={accept}
         multiple={multiple}
         className={cn(
-          "flex h-full w-full rounded-md border-2 px-3 py-2 text-base placeholder:text-muted-foreground focus:border-text focus:outline-none disabled:opacity-50",
+          "flex size-full rounded-md border-2 px-3 py-2 text-base placeholder:text-muted-foreground focus:border-text focus:outline-none disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/features/ui/select.tsx
+++ b/src/features/ui/select.tsx
@@ -1,97 +1,103 @@
 import * as RadixSelect from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
-import React, { forwardRef } from "react"
+import React, { FC, forwardRef } from "react"
 
-import Typography from "@/components/typography" // adjust import based on your file structure
-import { cn } from "@/lib/utils" // adjust import based on your file structure
+import { cn } from "@/lib/utils"
+
+type SelectOption = { label: string; value: string }
 
 export interface SelectProps {
   label?: string
   preventEmpty?: boolean
-  groups: { label: string; options: { value: string; label: string }[] }[]
-  className?: string // Added className prop here
-  onValueChange: (value: string) => void
+  options: SelectOption[] | { label: string; options: SelectOption[] }[]
+  className?: string
   value: string
+  onValueChange: (value: string) => void
   disabled?: boolean
 }
 
-const Select = forwardRef<HTMLButtonElement, SelectProps>(
-  ({ className, groups, label, preventEmpty, onValueChange, value, disabled, ...props }, ref) => {
-    return (
-      <RadixSelect.Root onValueChange={onValueChange} value={value} disabled={disabled}>
-        <RadixSelect.Trigger
-          className={cn(
-            "inline-flex h-[35px] items-center justify-center gap-[5px] rounded bg-altBackgroundShade px-[15px] text-[13px] leading-none text-text shadow-[0_2px_10px] shadow-black/10 outline-none hover:bg-altBackground focus:shadow-[0_0_0_2px] focus:shadow-black data-[placeholder]:text-textMuted",
-            className
-          )}
-          aria-label={label}
-          ref={ref}
-          {...props}
-        >
-          <RadixSelect.Value placeholder={label || "Select"} />
-          <RadixSelect.Icon className="text-text">
+const EMPTY_VALUE = "_"
+
+const Select: FC<SelectProps> = ({ className, label, options, preventEmpty, value, disabled, onValueChange }) => {
+  return (
+    <RadixSelect.Root
+      value={value}
+      disabled={disabled}
+      onValueChange={val => onValueChange(val === EMPTY_VALUE ? "" : val)}
+    >
+      <RadixSelect.Trigger
+        className={cn(
+          `flex size-full max-h-11 items-center justify-between overflow-hidden text-ellipsis whitespace-nowrap rounded-md border-2 px-3 py-2 pr-7 text-base placeholder:text-muted-foreground focus:border-text focus:outline-none disabled:opacity-50 ${disabled ? "cursor-default" : "cursor-pointer border-2 hover:bg-altBackground"}`,
+          className
+        )}
+        aria-label={label}
+        disabled={disabled}
+      >
+        <RadixSelect.Value placeholder={label || "Select"} />
+        <RadixSelect.Icon className="h-6 w-6">
+          <ChevronDown />
+        </RadixSelect.Icon>
+      </RadixSelect.Trigger>
+      <RadixSelect.Portal>
+        <RadixSelect.Content className="rounded-md border-2 border-text bg-altBackground" position="popper">
+          <RadixSelect.ScrollUpButton className="flex h-11 cursor-default items-center justify-center bg-altBackground text-text">
+            <ChevronUp />
+          </RadixSelect.ScrollUpButton>
+          <RadixSelect.Viewport className="p-2 uppercase text-muted-foreground">
+            <SelectItem
+              value={EMPTY_VALUE}
+              aria-label={label}
+              className={`${preventEmpty && "hidden bg-underline underline underline-offset-2"}`}
+            >
+              {label || "Select"}
+            </SelectItem>
+            <RadixSelect.Separator className={`m-1 h-[1px] bg-border ${preventEmpty && "hidden"}`} />
+            {options.map(option =>
+              "options" in option ? (
+                <RadixSelect.Group key={option.label} className="overflow-hidden text-ellipsis whitespace-nowrap">
+                  {option.label}
+                  {option.options?.map(({ value, label }) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </RadixSelect.Group>
+              ) : (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              )
+            )}
+          </RadixSelect.Viewport>
+          <RadixSelect.ScrollDownButton className="flex h-6 cursor-default items-center justify-center bg-altBackground text-text">
             <ChevronDown />
-          </RadixSelect.Icon>
-        </RadixSelect.Trigger>
-        <RadixSelect.Portal>
-          <RadixSelect.Content
-            className="overflow-hidden rounded-md bg-altBackground shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)]"
-            position="popper"
-          >
-            <RadixSelect.ScrollUpButton className="flex h-[25px] cursor-default items-center justify-center bg-altBackground text-text">
-              <ChevronUp />
-            </RadixSelect.ScrollUpButton>
-            <RadixSelect.Viewport className="p-[5px]">
-              {groups.map((group, groupIndex) => (
-                <React.Fragment key={groupIndex}>
-                  <RadixSelect.Group>
-                    <Typography variant="span" className="px-[25px] text-xs leading-[25px] text-text">
-                      {group.label}
-                    </Typography>
-                    {!preventEmpty && groupIndex === 0 && (
-                      <SelectItem value="placeholder" aria-label={label}>
-                        {label || "Select"}
-                      </SelectItem>
-                    )}
-                    {group.options.map(({ value, label }) => (
-                      <SelectItem key={value} value={value}>
-                        {label}
-                      </SelectItem>
-                    ))}
-                  </RadixSelect.Group>
-                  {groupIndex < groups.length - 1 && <RadixSelect.Separator className="m-[5px] h-[1px] bg-border" />}
-                </React.Fragment>
-              ))}
-            </RadixSelect.Viewport>
-            <RadixSelect.ScrollDownButton className="flex h-[25px] cursor-default items-center justify-center bg-altBackground text-text">
-              <ChevronDown />
-            </RadixSelect.ScrollDownButton>
-          </RadixSelect.Content>
-        </RadixSelect.Portal>
-      </RadixSelect.Root>
-    )
-  }
-)
+          </RadixSelect.ScrollDownButton>
+        </RadixSelect.Content>
+      </RadixSelect.Portal>
+    </RadixSelect.Root>
+  )
+}
+
+Select.displayName = "Select"
+
+export { Select }
 
 const SelectItem = forwardRef<HTMLDivElement, RadixSelect.SelectItemProps & { children: React.ReactNode }>(
   ({ children, className, ...props }, ref) => (
     <RadixSelect.Item
       className={cn(
-        "relative flex h-[25px] select-none items-center rounded-[3px] pl-[25px] pr-[35px] text-[13px] leading-none text-text data-[disabled]:pointer-events-none data-[highlighted]:bg-focus data-[disabled]:text-textMuted data-[highlighted]:text-altBackground data-[highlighted]:outline-none",
+        "relative flex h-6 max-h-11 cursor-pointer items-center overflow-hidden text-ellipsis whitespace-nowrap rounded-sm pl-7 pr-2 normal-case text-text data-[disabled]:pointer-events-none data-[highlighted]:bg-focus data-[disabled]:text-textMuted data-[highlighted]:text-altBackground data-[highlighted]:outline-none",
         className
       )}
       {...props}
       ref={ref}
     >
       <RadixSelect.ItemText>{children}</RadixSelect.ItemText>
-      <RadixSelect.ItemIndicator className="absolute left-0 inline-flex w-[25px] items-center justify-center">
-        <Check />
+      <RadixSelect.ItemIndicator className="absolute left-1">
+        <Check className="h-6 w-6" />
       </RadixSelect.ItemIndicator>
     </RadixSelect.Item>
   )
 )
 
-Select.displayName = "Select"
 SelectItem.displayName = "SelectItem"
-
-export { Select }


### PR DESCRIPTION
This pull request primarily focuses on improving the user interface and enhancing the codebase's structure. The most significant changes involve modifying the `Selectors` and `Input` components in the `selectors.tsx` and `input.tsx` files, respectively, and a substantial overhaul of the `Select` component in the `select.tsx` file.

Changes to `Selectors` and `Input` components:

* [`src/app/settings/admin/selectors.tsx`](diffhunk://#diff-d8c7a0319bdb53bcc2e684ece735ca738aa7582da4020f753306e673fbb441c8L40-R43): Simplified the styling of the div elements and changed the `Select` component's `value` prop and `groups` prop to `options` in the `Selectors` component. [[1]](diffhunk://#diff-d8c7a0319bdb53bcc2e684ece735ca738aa7582da4020f753306e673fbb441c8L40-R43) [[2]](diffhunk://#diff-d8c7a0319bdb53bcc2e684ece735ca738aa7582da4020f753306e673fbb441c8L56-R59)
* [`src/features/ui/input.tsx`](diffhunk://#diff-5e8744cc07b638fc98d68957d68803c70cc7c1cd8492919bb80eca87726ccaf5L19-R19): Updated the className in the `Input` component to adjust the element's size.

Major overhaul of `Select` component:

* [`src/features/ui/select.tsx`](diffhunk://#diff-60e284006943a508e738bbbc2f548d96c93d7117d2bf0c83444842ba102c576dL3-L97): The `Select` component has been significantly refactored. The `groups` prop has been replaced with `options`, and the `onValueChange` function has been updated. The component's styling and structure have also been modified, including changes to the `RadixSelect` elements and the addition of the `SelectItem` component.


<img width="800" alt="image" src="https://github.com/QDAP-DATAAI/qchat/assets/162237166/a59a578c-e082-4662-b0f6-d76139be34c6">
