### PR TITLE
Addition of Short Message Warning and better use of Context for disabling buttons when Chat Thread is Locked

### DIFF
--- a/src/components/chat/chat-row.tsx
+++ b/src/components/chat/chat-row.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { OctagonAlert, SearchX } from "lucide-react"
+import { OctagonAlert, SearchX, SmilePlus } from "lucide-react"
 import React, { FC, useState } from "react"
 
 import ErrorBoundary from "@/components/error-boundary"
@@ -20,7 +20,7 @@ interface ChatRowProps {
   chatThreadId: string
   showAssistantButtons: boolean
   threadLocked?: boolean
-  disableButtons?: boolean // Add this prop
+  disableButtons?: boolean
 }
 
 export const ChatRow: FC<ChatRowProps> = props => {
@@ -30,6 +30,8 @@ export const ChatRow: FC<ChatRowProps> = props => {
     props.type === "assistant" ? props.message.content : `**${props.name || "You"}**: ${props.message.content}`
 
   const fleschScore = calculateFleschKincaidScore(props.message.content)
+
+  const isShortInput = (text: string): boolean => text.length < 30
 
   return (
     <article className={"container mx-auto flex flex-col py-1 pb-2"}>
@@ -86,6 +88,20 @@ export const ChatRow: FC<ChatRowProps> = props => {
               </div>
               <div className="flex items-center justify-center">
                 <OctagonAlert size={20} />
+              </div>
+            </div>
+          )}
+          {props.type !== "assistant" && isShortInput(props.message.content) && (
+            <div
+              className="my-2 flex max-w-none justify-center space-x-2 rounded-md bg-information p-2 text-base md:text-base"
+              tabIndex={0}
+              aria-label="Input Warning"
+            >
+              <div className="flex items-center justify-center">
+                <SmilePlus size={20} />
+              </div>
+              <div className="flex flex-col items-center justify-center text-center">
+                Your message is a bit short. For the best results, please provide more context or details.
               </div>
             </div>
           )}

--- a/src/components/chat/chat-row.tsx
+++ b/src/components/chat/chat-row.tsx
@@ -19,12 +19,12 @@ interface ChatRowProps {
   type: ChatRole
   chatThreadId: string
   showAssistantButtons: boolean
-  threadLocked?: boolean
+  lockMessage?: boolean
   disableButtons?: boolean
 }
 
 export const ChatRow: FC<ChatRowProps> = props => {
-  const { setInput } = useChatContext()
+  const { setInput, chatThreadLocked } = useChatContext()
   const [feedbackMessage, setFeedbackMessage] = useState("")
   const content =
     props.type === "assistant" ? props.message.content : `**${props.name || "You"}**: ${props.message.content}`
@@ -37,7 +37,7 @@ export const ChatRow: FC<ChatRowProps> = props => {
     <article className={"container mx-auto flex flex-col py-1 pb-2"}>
       <ErrorBoundary fallback={<ErrorSection />}>
         <section
-          className={`prose prose-slate max-w-full flex-col gap-4 overflow-hidden break-words rounded-md px-4 py-2 text-base text-text dark:prose-invert prose-p:leading-relaxed prose-pre:p-0 md:text-base ${props.threadLocked && "border-4 border-error"} ${props.type === "assistant" && "bg-backgroundShade"} ${props.type != "assistant" && "bg-altBackgroundShade"}`}
+          className={`prose prose-slate max-w-full flex-col gap-4 overflow-hidden break-words rounded-md px-4 py-2 text-base text-text dark:prose-invert prose-p:leading-relaxed prose-pre:p-0 md:text-base ${props.lockMessage && "border-4 border-error"} ${props.type === "assistant" && "bg-backgroundShade"} ${props.type != "assistant" && "bg-altBackgroundShade"}`}
         >
           {props.type === "assistant" && (
             <div className="flex w-full items-center justify-between">
@@ -64,7 +64,7 @@ export const ChatRow: FC<ChatRowProps> = props => {
           >
             <div className="size-full items-center justify-between">
               <Markdown content={content} />
-              {!!props.message.contentFilterResult && !props.disableButtons && (
+              {!!props.message.contentFilterResult && !props.disableButtons && !chatThreadLocked && (
                 <RewriteMessageButton
                   fleschScore={fleschScore}
                   message={props.message}

--- a/src/components/chat/chat-row.tsx
+++ b/src/components/chat/chat-row.tsx
@@ -8,6 +8,7 @@ import { Markdown } from "@/components/markdown/markdown"
 import Typography from "@/components/typography"
 import { calculateFleschKincaidScore } from "@/features/chat/chat-services/chat-flesch"
 import { useChatContext } from "@/features/chat/chat-ui/chat-context"
+import { SHORT_MESSAGE_LENGTH } from "@/features/chat/constants"
 import { ChatRole, PromptMessage } from "@/features/chat/models"
 import { AssistantButtons } from "@/features/ui/assistant-buttons"
 import { RewriteMessageButton } from "@/features/ui/assistant-buttons/rewrite-message-button"
@@ -31,7 +32,7 @@ export const ChatRow: FC<ChatRowProps> = props => {
 
   const fleschScore = calculateFleschKincaidScore(props.message.content)
 
-  const isShortInput = (text: string): boolean => text.length < 30
+  const isShortInput = (text: string): boolean => text.length < SHORT_MESSAGE_LENGTH
 
   return (
     <article className={"container mx-auto flex flex-col py-1 pb-2"}>

--- a/src/features/chat/chat-services/chat-message-service.ts
+++ b/src/features/chat/chat-services/chat-message-service.ts
@@ -3,6 +3,7 @@
 import { SqlQuerySpec } from "@azure/cosmos"
 
 import { getTenantId, userHashedId } from "@/features/auth/helpers"
+import { MESSAGE_COUNT } from "@/features/chat/constants"
 import {
   AssistantChatMessageModel,
   ChatRecordType,
@@ -45,7 +46,7 @@ export const FindAllChatMessagesForCurrentUser = async (
 
 export const FindTopChatMessagesForCurrentUser = async (
   chatThreadId: string,
-  top = 30
+  top = MESSAGE_COUNT
 ): ServerActionResponseAsync<(UserChatMessageModel | AssistantChatMessageModel)[]> => {
   try {
     const [userId, tenantId] = await Promise.all([userHashedId(), getTenantId()])

--- a/src/features/chat/chat-ui/chat-message-container.tsx
+++ b/src/features/chat/chat-ui/chat-message-container.tsx
@@ -79,7 +79,7 @@ export const ChatMessageContainer: React.FC<Props> = ({ chatThreadId }) => {
                 type={message.role as ChatRole}
                 chatThreadId={chatThreadId}
                 showAssistantButtons={index === messages.length - 1 ? !isLoading : true}
-                threadLocked={index === messages.length - 1 && chatThreadLocked}
+                lockMessage={index === messages.length - 1 && chatThreadLocked}
               />
             ))
           : selectedTab === "transcription"

--- a/src/features/chat/constants.ts
+++ b/src/features/chat/constants.ts
@@ -1,3 +1,5 @@
 export const DEFAULT_MONTHS_AGO = 3
 export const DEFAULT_DAYS_AGO = 7
 export const MAX_DOCUMENT_SIZE = 1024 * 1024 * 10
+export const SHORT_MESSAGE_LENGTH = 30
+export const MESSAGE_COUNT = 30

--- a/src/features/reporting/reporting-message-container.tsx
+++ b/src/features/reporting/reporting-message-container.tsx
@@ -59,7 +59,7 @@ export const ReportingMessageContainer: FC<Props> = ({ chatThreadId }) => {
                 type={message.role as ChatRole}
                 chatThreadId={chatThreadId}
                 showAssistantButtons={index === messages.length - 1 ? !isLoading : true}
-                threadLocked={index === messages.length - 1 && chatThreadLocked}
+                lockMessage={index === messages.length - 1 && chatThreadLocked}
                 disableButtons={true}
               />
             ))

--- a/src/features/ui/assistant-buttons/rewrite-message-button.tsx
+++ b/src/features/ui/assistant-buttons/rewrite-message-button.tsx
@@ -4,6 +4,7 @@ import { Sparkles, Sparkle } from "lucide-react"
 import React, { useState, useCallback } from "react"
 
 import useSmartGen from "@/components/hooks/use-smart-gen"
+import { useChatContext } from "@/features/chat/chat-ui/chat-context"
 import { PromptMessage } from "@/features/chat/models"
 import logger from "@/features/insights/app-insights"
 import { useSettingsContext } from "@/features/settings/settings-provider"
@@ -56,6 +57,7 @@ const RewriteMessageButtonInternal: React.FC<{
 }> = ({ toolName, context, input, onAssistantButtonClick }) => {
   const { iconSize, buttonClass } = useButtonStyles()
   const { config } = useSettingsContext()
+  const { chatThreadLocked } = useChatContext()
 
   const { smartGen } = useSmartGen(config.tools || [])
 
@@ -90,6 +92,7 @@ const RewriteMessageButtonInternal: React.FC<{
       className={`${buttonClass} ${rewriteClicked ? "bg-button text-buttonText" : ""}`}
       title="Rewrite with suggestions"
       onClick={handleRewriteWithSuggestions}
+      disabled={chatThreadLocked}
     >
       {rewriteClicked ? (
         <Sparkles size={iconSize} className={isLoading ? "animate-spin" : ""} />


### PR DESCRIPTION
This pull request primarily focuses on enhancing the chat functionality in the application. The most significant changes include the addition of a new icon, refactoring of props in the `ChatRow` component, implementation of a warning for short input messages, and the integration of the chat thread lock status into various components.

Addition of new icon:
* [`src/components/chat/chat-row.tsx`](diffhunk://#diff-027a35f5584ceef68685cfaa6d21295fe676501f04e730543d13498cb70b5dd2L3-R3): The `SmilePlus` icon from `lucide-react` has been imported into the file.

Refactoring of `ChatRow` component:
* [`src/components/chat/chat-row.tsx`](diffhunk://#diff-027a35f5584ceef68685cfaa6d21295fe676501f04e730543d13498cb70b5dd2L22-R40): The `threadLocked` prop has been replaced with `lockMessage` in the `ChatRowProps` interface. The `setInput` method from `useChatContext` has been replaced with `chatThreadLocked`. The `className` attribute of the `section` element has been updated to use `lockMessage` instead of `threadLocked`. [[1]](diffhunk://#diff-027a35f5584ceef68685cfaa6d21295fe676501f04e730543d13498cb70b5dd2L22-R40) [[2]](diffhunk://#diff-027a35f5584ceef68685cfaa6d21295fe676501f04e730543d13498cb70b5dd2L65-R67)

Implementation of short input warning:
* [`src/components/chat/chat-row.tsx`](diffhunk://#diff-027a35f5584ceef68685cfaa6d21295fe676501f04e730543d13498cb70b5dd2R94-R107): A new method `isShortInput` has been added to check if the text length is less than 30. A new warning message has been added to inform users when their input is too short.

Integration of chat thread lock status:
* `src/features/chat/chat-ui/chat-message-container.tsx` and `src/features/reporting/reporting-message-container.tsx`: The `threadLocked` prop has been replaced with `lockMessage` in the `ChatMessageContainer` and `ReportingMessageContainer` components. [[1]](diffhunk://#diff-66d171166e4023058f819822019dea9362992c85c7c5e769a1c207017002db41L82-R82) [[2]](diffhunk://#diff-1acebd20d5f1cbfe5e3b86eab30277e16a45a66d1eb4406f6d540b26db15174cL62-R62)
* [`src/features/ui/assistant-buttons/rewrite-message-button.tsx`](diffhunk://#diff-c24a5ad281f781fe19595438994d498b57d4bde5f68e7351b7af63669acc7fd3R7): The `chatThreadLocked` status from `useChatContext` has been imported and used to disable the `RewriteMessageButton` when the chat thread is locked. [[1]](diffhunk://#diff-c24a5ad281f781fe19595438994d498b57d4bde5f68e7351b7af63669acc7fd3R7) [[2]](diffhunk://#diff-c24a5ad281f781fe19595438994d498b57d4bde5f68e7351b7af63669acc7fd3R95)