### PR TITLE
feat: Add Undo and Undo2 icons to ChatFileTranscription component

### DIFF
--- a/src/components/chat/chat-file-transcription.tsx
+++ b/src/components/chat/chat-file-transcription.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { DownloadIcon, CaptionsIcon, FileTextIcon, SaveIcon } from "lucide-react"
+import { DownloadIcon, CaptionsIcon, FileTextIcon, SaveIcon, Undo, Undo2 } from "lucide-react"
 import { FC, useCallback, useState } from "react"
 
 import { APP_NAME } from "@/app-global"
@@ -81,15 +81,22 @@ export const ChatFileTranscription: FC<ChatFileTranscriptionProps> = props => {
           </Typography>
           <div className="flex flex-1 justify-between">
             <div className="flex gap-2">
-              <Button variant="destructive" onClick={reset} ariaLabel="Reset from original" className={buttonClass}>
+              <Button
+                variant="destructive"
+                onClick={reset}
+                ariaLabel="Reset from original"
+                className={`${buttonClass} flex gap-2`}
+              >
+                <Undo2 size={iconSize} />
                 Reset
               </Button>
               <Button
-                variant="outline"
+                variant="destructive"
                 onClick={undo}
-                className={`${buttonClass} hover:bg-error`}
+                className={`${buttonClass} flex gap-2`}
                 ariaLabel="Reset from latest update"
               >
+                <Undo size={iconSize} />
                 Undo
               </Button>
               <Button

--- a/src/components/chat/chat-transcript-change.tsx
+++ b/src/components/chat/chat-transcript-change.tsx
@@ -55,7 +55,7 @@ export const ChatTranscriptEditor: React.FC = () => {
                 size={16}
                 className={`${editorType === "text" ? "" : "rotate-90"} transition-all duration-300 ease-in`}
               />
-              {`Switch to ${editorType === "text" ? "Form" : "Text"} Editor`}
+              {`Switch to ${editorType === "text" ? "Form" : "Text"}`}
             </Button>
           </Typography>
           <Panel ref={rightPanel}>


### PR DESCRIPTION
This pull request primarily focuses on changes in the `src/components/chat/chat-file-transcription.tsx` and `src/components/chat/chat-transcript-change.tsx` files. The key modifications include the addition of new icons from `lucide-react`, changes in the `Button` components, and a slight adjustment in the text displayed in the `ChatTranscriptEditor` component.

Key changes:

* [`src/components/chat/chat-file-transcription.tsx`](diffhunk://#diff-1999aca0416f0b7591be8cb7d654a40e1f1fc14427393fbef6ea7a82be1f9ec9L3-R3): Imported new icons `Undo` and `Undo2` from `lucide-react` for use in the `Button` components.
* [`src/components/chat/chat-file-transcription.tsx`](diffhunk://#diff-1999aca0416f0b7591be8cb7d654a40e1f1fc14427393fbef6ea7a82be1f9ec9L84-R99): Adjusted the `Button` components in the `ChatFileTranscription` component. The `Reset` button now includes the `Undo2` icon and the `Undo` button has been changed to a `destructive` variant and includes the `Undo` icon.
* [`src/components/chat/chat-transcript-change.tsx`](diffhunk://#diff-f9027eff44e3b9eebad2a1dfc0d62c72f9b922e2f6ab3eb4d0cfbfef8dc58ad9L58-R58): Simplified the text displayed in the `ChatTranscriptEditor` component. The word "Editor" has been removed from the button's label.