### PR TITLE
feat: Replace agency name variable in tenant details form

### DIFF
--- a/src/features/settings/tenant-details/tenant-details-form.tsx
+++ b/src/features/settings/tenant-details/tenant-details-form.tsx
@@ -117,7 +117,7 @@ export const TenantDetailsForm: React.FC<{ tenant: TenantDetails }> = ({ tenant 
       </Typography>
       <Typography variant="h5" className="mt-4">
         <strong>Notice:</strong> Updating the context prompt here will append the message to the global system message.
-        This setting is regularly audited by the ${AGENCY_NAME} AI Unit.
+        This setting is regularly audited by the {AGENCY_NAME} AI Unit.
       </Typography>
       <Typography variant="h5" className="mt-4">
         Current Prompt:


### PR DESCRIPTION
The code changes involve replacing the agency name variable in the tenant details form. This change ensures that the correct agency name is displayed in the context prompt message. The agency name is now retrieved from the {AGENCY_NAME} variable, which is regularly audited by the AI Unit.