### PR TITLE
feat- added evaluationMetrics (null values) to chat thread

### DIFF
--- a/src/features/chat/chat-services/chat-thread-service.ts
+++ b/src/features/chat/chat-services/chat-thread-service.ts
@@ -254,6 +254,16 @@ export const CreateChatThread = async (title?: string): ServerActionResponseAsyn
       conversationSensitivity: ConversationSensitivity.Official,
       type: ChatRecordType.Thread,
       chatOverFileName: "",
+      evaluationMetrics: {
+        outputLength: null,
+        interactionTimeMin: null,
+        numberOfCompletedTasks: null,
+        interactionTurns: null,
+        userSatisfaction: null,
+        productivityScoreEfficiencyFocused: null,
+        productivityScoreTaskCompletionFocused: null,
+        productivityScoreUserSatisfactionFocused: null,
+      },
     }
 
     const container = await HistoryContainer()

--- a/src/features/chat/models.ts
+++ b/src/features/chat/models.ts
@@ -95,6 +95,18 @@ export interface ChatThreadModel {
   internalReference?: string
   isDisabled: boolean
   contentFilterTriggerCount?: number
+  evaluationMetrics?: EvaluationMetrics
+}
+
+export interface EvaluationMetrics {
+  outputLength: number | null
+  interactionTimeMin: number | null
+  numberOfCompletedTasks: number | null
+  interactionTurns: number | null
+  userSatisfaction: number | null
+  productivityScoreEfficiencyFocused: number | null
+  productivityScoreTaskCompletionFocused: number | null
+  productivityScoreUserSatisfactionFocused: number | null
 }
 
 export interface PromptBody {


### PR DESCRIPTION
This pull request includes enhancements to the chat thread service and models by adding evaluation metrics. These changes aim to capture various performance and user satisfaction metrics for chat threads.

### Enhancements to chat thread service and models:

* [`src/features/chat/chat-services/chat-thread-service.ts`](diffhunk://#diff-bddad34450c7e7af3d06ffd22ebcde980e85c8af1017de49bfc10f96c7084758R257-R266): Added `evaluationMetrics` to the `CreateChatThread` function to track various performance and user satisfaction metrics.
* [`src/features/chat/models.ts`](diffhunk://#diff-f0481e710f6d6aec8cdd9f3707b9553d3e04d47c8bbcdea00d37b29e5b2f3d4cR98-R109): Introduced the `EvaluationMetrics` interface and added it to the `ChatThreadModel` to define and store metrics such as `outputLength`, `interactionTimeMin`, `numberOfCompletedTasks`, `interactionTurns`, `userSatisfaction`, and various productivity scores.