### PR TITLE
chore: fix unit tests

### DIFF
--- a/src/features/common/services/cosmos.ts
+++ b/src/features/common/services/cosmos.ts
@@ -1,45 +1,6 @@
-import { CosmosClient, CosmosClientOptions, Container, PartitionKeyDefinition } from "@azure/cosmos"
-import { DefaultAzureCredential, DeviceCodeCredential } from "@azure/identity"
+import { Container, PartitionKeyDefinition } from "@azure/cosmos"
 
-import logger from "@/features/insights/app-insights"
-
-export const CONFIG = {
-  endpoint: process.env.COSMOS_DB_ENDPOINT || "https://your-cosmos-account.documents.azure.com:443/",
-  dbName: process.env.AZURE_COSMOSDB_DB_NAME || "localdev",
-}
-export type CosmosConfig = typeof CONFIG
-
-let cosmosClient: CosmosClient | null = null
-
-/**
- * Create Cosmos Client with Azure AD Authentication
- * @param config CosmosConfig
- * @returns CosmosClient
- */
-export function createCosmosClient(config: CosmosConfig): CosmosClient {
-  if (cosmosClient) return cosmosClient
-
-  try {
-    let credential
-
-    if (process.env.NODE_ENV === "development") {
-      credential = new DeviceCodeCredential()
-    } else {
-      credential = new DefaultAzureCredential()
-    }
-
-    const options: CosmosClientOptions = {
-      endpoint: config.endpoint,
-      aadCredentials: credential,
-    }
-
-    cosmosClient = new CosmosClient(options)
-    return cosmosClient
-  } catch (error) {
-    logger.error(`Failed to create CosmosClient: ${JSON.stringify(error)}`)
-    throw new Error(`Failed to create CosmosClient: ${JSON.stringify(error)}`)
-  }
-}
+import { CONFIG, CosmosConfig, createCosmosClient } from "./cosmos-auth"
 
 const _containerCache: Map<string, Container> = new Map()
 


### PR DESCRIPTION
This pull request includes changes refactoring the authentication process to use Azure Active Directory (AAD) credentials and simplifying the client creation logic.

### Refactoring and Authentication Updates:

* [`src/features/common/services/cosmos-auth.ts`](diffhunk://#diff-d892c4ec681b0c1ac1787c759407f5c973e45af7f83f108c345329d5537a126aL1-L48): Refactored to use Azure AD credentials (`DeviceCodeCredential` for development and `DefaultAzureCredential` for other environments) for Cosmos DB client creation. Removed the old token fetching and validation logic.

* [`src/features/common/services/cosmos.ts`](diffhunk://#diff-c268ff1a6fc191f99321155ee9ec7323f65e574819c9711177ad495e8059c428L1-R3): Updated to import the new Cosmos client creation function from `cosmos-auth.ts` and removed the old client creation logic.

### Unit Test Updates:

* [`src/tests/unit/cosmos.test.ts`](diffhunk://#diff-5ffe5b74f9a398cb689412d209ea25a72c83a3160a8e4d560eac1c75aeed4859L4): Removed tests related to the old token fetching and validation logic. Updated tests to reflect the new client creation logic and ensure proper mocking of the Cosmos client. [[1]](diffhunk://#diff-5ffe5b74f9a398cb689412d209ea25a72c83a3160a8e4d560eac1c75aeed4859L4) [[2]](diffhunk://#diff-5ffe5b74f9a398cb689412d209ea25a72c83a3160a8e4d560eac1c75aeed4859L24-L95) [[3]](diffhunk://#diff-5ffe5b74f9a398cb689412d209ea25a72c83a3160a8e4d560eac1c75aeed4859L110-R38) [[4]](diffhunk://#diff-5ffe5b74f9a398cb689412d209ea25a72c83a3160a8e4d560eac1c75aeed4859L128-R74) [[5]](diffhunk://#diff-5ffe5b74f9a398cb689412d209ea25a72c83a3160a8e4d560eac1c75aeed4859L173-R86) [[6]](diffhunk://#diff-5ffe5b74f9a398cb689412d209ea25a72c83a3160a8e4d560eac1c75aeed4859L227-L232)